### PR TITLE
[OSA-141] Profile Section improvements

### DIFF
--- a/packages/api/src/services/users.ts
+++ b/packages/api/src/services/users.ts
@@ -22,6 +22,7 @@ export class UsersService implements IUserService {
     const { current, total, totalPoints, percentile } = result;
 
     return {
+      points: totalPoints,
       rank: this.getUserRank(totalPoints)?.rank ?? "",
       position: {
         current,

--- a/packages/schemas/src/user.ts
+++ b/packages/schemas/src/user.ts
@@ -6,6 +6,7 @@ export const userWalletSchema = z.string().min(1, "Wallet address is required").
 });
 
 export const profileSchema = z.object({
+  points: z.number(),
   rank: z.string(),
   position: z.object({
     current: z.number(),

--- a/packages/ui/src/components/account-sumary.tsx
+++ b/packages/ui/src/components/account-sumary.tsx
@@ -1,11 +1,9 @@
-import { useSuperchainRaffle } from "@/hooks/use-superchain-raffle";
 import { Skeleton } from "./ui/skeleton";
 import { useSuperchainPoints } from "@/hooks/use-superchain-points";
 import { useSuperchainProfile } from "@/hooks/use-superchain-profile";
 
 export const AccountSummary: React.FC = () => {
   const { isPending: isPointsPending, balance } = useSuperchainPoints();
-  const { isPending: isTicketsPending, currentRaffle } = useSuperchainRaffle();
   const { isPending: isProfilePending, profile } = useSuperchainProfile();
 
   return (
@@ -32,7 +30,7 @@ export const AccountSummary: React.FC = () => {
         )}
       </div>
 
-      <div className="grid grid-cols-2 divide-x lg:border-l">
+      <div className="lg:border-l">
         <div className="lg:w-52 lg:py-6 lg:space-y-2 flex flex-col justify-center">
           {isPointsPending ? (
             <Skeleton className="h-10 w-16 mx-auto" />
@@ -44,19 +42,6 @@ export const AccountSummary: React.FC = () => {
               <div className="text-center text-xs lg:font-medium">
                 SC Points
               </div>
-            </>
-          )}
-        </div>
-
-        <div className="lg:w-52 lg:py-6 lg:space-y-2 flex flex-col justify-center">
-          {isTicketsPending ? (
-            <Skeleton className="h-10 w-16 mx-auto" />
-          ) : (
-            <>
-              <div className="text-center font-medium lg:text-2xl lg:font-semibold">
-                {currentRaffle?.claimedTickets.toString() ?? 0}
-              </div>
-              <div className="text-center text-xs lg:font-medium">Tickets</div>
             </>
           )}
         </div>

--- a/packages/ui/src/components/account-sumary.tsx
+++ b/packages/ui/src/components/account-sumary.tsx
@@ -1,9 +1,7 @@
 import { Skeleton } from "./ui/skeleton";
-import { useSuperchainPoints } from "@/hooks/use-superchain-points";
 import { useSuperchainProfile } from "@/hooks/use-superchain-profile";
 
 export const AccountSummary: React.FC = () => {
-  const { isPending: isPointsPending, balance } = useSuperchainPoints();
   const { isPending: isProfilePending, profile } = useSuperchainProfile();
 
   return (
@@ -19,12 +17,9 @@ export const AccountSummary: React.FC = () => {
             <h1 className="font-semibold text-2xl text-center lg:text-left">
               {profile.rank}
             </h1>
-            <div className="flex flex-row justify-between">
-              <div>
-                <span className="text-base font-medium">Position:</span>
-                <span className="text-base font-semibold ml-2">{profile.position.current}/{profile.position.total}</span>
-              </div>
-              <span className="text-base text-slate-400 font-semibold">{profile.position.percentile}%</span>
+            <div>
+              <span className="text-base font-medium">Position:</span>
+              <span className="text-base font-semibold ml-2">{profile.position.current}/{profile.position.total}</span>
             </div>
           </>
         )}
@@ -32,12 +27,12 @@ export const AccountSummary: React.FC = () => {
 
       <div className="lg:border-l">
         <div className="lg:w-52 lg:py-6 lg:space-y-2 flex flex-col justify-center">
-          {isPointsPending ? (
+          {isProfilePending ? (
             <Skeleton className="h-10 w-16 mx-auto" />
           ) : (
             <>
               <div className="text-center font-medium lg:text-2xl lg:font-semibold">
-                {balance.toString() ?? 0}
+                {profile.points ?? 0}
               </div>
               <div className="text-center text-xs lg:font-medium">
                 SC Points

--- a/packages/ui/src/components/home/send-asset-dialog/asset-selector.tsx
+++ b/packages/ui/src/components/home/send-asset-dialog/asset-selector.tsx
@@ -43,7 +43,7 @@ const AssetSelector = () => {
             <FormLabel>Asset</FormLabel>
             <FormControl>
               <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <SelectTrigger className="h-12 focus:ring-0">
+                <SelectTrigger className="h-14 focus:ring-0">
                   <SelectValue placeholder="Select a token" />
                 </SelectTrigger>
                 <SelectContent>

--- a/packages/ui/src/components/home/send-asset-dialog/send-asset-dialog.tsx
+++ b/packages/ui/src/components/home/send-asset-dialog/send-asset-dialog.tsx
@@ -12,6 +12,7 @@ import { useSuperChainAccount } from "@/hooks/use-smart-account";
 import { useToast } from "@/hooks/use-toast";
 import { useSendAsset } from "@/hooks/use-send-asset";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 const sendAssetSchema = z.object({
   asset: z.string({required_error: "Asset is required"}).transform(val => getAddress(val)),
@@ -113,27 +114,29 @@ export const SendAssetDialog = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Send tokens</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} 
-            className='flex flex-col justify-between w-full h-full gap-14'>
-            <div className="flex flex-col gap-4" >
-              <AssetSelector  />
-              <AmountField  />
-              <DestinationAddressField  />
-            </div>
-            <Button
-              type="submit"
-              className="w-full"
-              loading={form.formState.isSubmitting}
-            >
+      <DialogContent className="sm:max-w-md">
+        <ScrollArea className="max-h-screen">
+          <DialogHeader>
+            <DialogTitle>Send tokens</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} 
+              className='flex flex-col justify-between w-full h-full gap-14'>
+              <div className="flex flex-col gap-4" >
+                <AssetSelector  />
+                <AmountField  />
+                <DestinationAddressField  />
+              </div>
+              <Button
+                type="submit"
+                className="w-full"
+                loading={form.formState.isSubmitting}
+              >
                 Continue
-            </Button>
-          </form>
-        </Form>
+              </Button>
+            </form>
+          </Form>
+        </ScrollArea>
       </DialogContent>
     </Dialog>
   );

--- a/packages/ui/src/components/superchain-badges.tsx
+++ b/packages/ui/src/components/superchain-badges.tsx
@@ -57,7 +57,7 @@ export const SuperchainBadges: React.FC = () => {
 
   if (isPending) {
     return (
-      <div className="w-full">
+      <div className="w-full xl:w-[35%] 2xl:w-[45%]">
         <div className="mb-4 font-medium">Accomplishments</div>
         <div className="bg-white border rounded-lg p-8 space-y-4 h-[430px]">
           <Skeleton className="h-4 w-1/2 rounded-md" />
@@ -70,7 +70,7 @@ export const SuperchainBadges: React.FC = () => {
 
   if (!badges || badges.length === 0) {
     return (
-      <div>
+      <div className="xl:w-[35%] 2xl:w-[45%]">
         <div className="mb-4 font-medium">Accomplishments</div>
         <div className="bg-white border rounded-lg p-8 flex flex-col justify-center items-center h-[430px]">
           <img src={emptySvg} alt="" className="mb-11 h-20 w-20" />
@@ -87,41 +87,43 @@ export const SuperchainBadges: React.FC = () => {
 
 
   return (
-    <div>
+    <div className="xl:w-[35%] 2xl:w-[45%]">
       <div className="mb-4 font-medium">Accomplishments</div>
-      <ScrollArea className="h-full">
-        <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
-          {sortedBadges.map((badge) => (
-            <div
-              key={badge.id}
-              className={cn(
-                "flex gap-3 items-center p-6 rounded-lg bg-white h-[100px] shadow-sm",
-                {
-                  "border border-primary": badge.status === "unclaimed",
-                }
-              )}
-            >
-              <img src={badge.image} alt="" className="h-[38px] w-[38px]" />
-              <div className="space-y-1">
-                <div className="font-semibold text-sm">{badge.name}</div>
-                <div className="text-xs">{badge.description}</div>
-                {badge.status === "claimed" && <div className="w-fit text-sm text-green-600 bg-green-100 border border-green-600 px-2 rounded">Claimed</div>}
-                {badge.status === "unclaimed" && (
-                  <Button
-                    onClick={() => onClaim(badge.id)}
-                    loading={isClaiming}
-                    className="flex items-center px-0 py-0 h-5 text-xs"
-                    variant="link"
-                  >
-                    <span>Claim Badge</span>
-                    <ArrowRight className="h-3 w-3" />
-                  </Button>
+      <div className="h-[430px]">
+        <ScrollArea className="h-full">
+          <div className="grid grid-cols-1 gap-2 2xl:grid-cols-2">
+            {sortedBadges.map((badge) => (
+              <div
+                key={badge.id}
+                className={cn(
+                  "flex gap-3 items-center p-6 rounded-lg bg-white h-[100px] shadow-sm",
+                  {
+                    "border border-primary": badge.status === "unclaimed",
+                  }
                 )}
+              >
+                <img src={badge.image} alt="" className="h-[38px] w-[38px]" />
+                <div className="space-y-1">
+                  <div className="font-semibold text-sm">{badge.name}</div>
+                  <div className="text-xs">{badge.description}</div>
+                  {badge.status === "claimed" && <div className="w-fit text-sm text-green-600 bg-green-100 border border-green-600 px-2 rounded">Claimed</div>}
+                  {badge.status === "unclaimed" && (
+                    <Button
+                      onClick={() => onClaim(badge.id)}
+                      loading={isClaiming}
+                      className="flex items-center px-0 py-0 h-5 text-xs"
+                      variant="link"
+                    >
+                      <span>Claim Badge</span>
+                      <ArrowRight className="h-3 w-3" />
+                    </Button>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      </ScrollArea>
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/components/superchain-points.tsx
+++ b/packages/ui/src/components/superchain-points.tsx
@@ -64,11 +64,10 @@ export const SuperchainPoints: React.FC = () => {
         <div className="bg-white border rounded-lg p-8 flex flex-col justify-center items-center h-[430px]">
           <img src={emptySvg} alt="" className="mb-11 h-20 w-20" />
           <div className="text-center mb-6 font-medium">
-            Oops! No rewards available at the moment
+            No rewards to claim...yet!
           </div>
           <div className="text-center text-muted-foreground">
-            Take a look at your accomplishments to keep earning and unlocking
-            rewards!
+            Engage with the chain to earn points and unlock fresh rewards.
           </div>
         </div>
       </div>
@@ -78,7 +77,7 @@ export const SuperchainPoints: React.FC = () => {
   return (
     <div className="xl:w-[30%] 2xl:w-[25%]">
       <div className="mb-4 font-medium">Claimable Rewards</div>
-      <div className="bg-white border rounded-lg p-8 h-[430px] flex flex-col">
+      <div className="bg-white border rounded-lg p-8 h-[430px] flex flex-col gap-4">
         <ScrollArea className="h-full">
           <ul className="divide-y">
             {unknownAmount > 0n && (
@@ -95,8 +94,8 @@ export const SuperchainPoints: React.FC = () => {
                 key={event.id}
                 className="flex justify-between first:pt-0 pt-4 pb-4"
               >
-                <div>
-                  <div>{event.type}</div>
+                <div className="xl:w-3/5">
+                  <div className="truncate">{event.type}</div>
                   <div className="text-xs">{shortenAddress(event.transactionHash)}</div>
                 </div>
                 <span className="font-semibold">{event.value} pts</span>
@@ -108,8 +107,8 @@ export const SuperchainPoints: React.FC = () => {
                 key={event.id}
                 className="flex justify-between first:pt-0 pt-4 pb-4 opacity-50"
               >
-                <div>
-                  <div>{event.type}</div>
+                <div className="xl:w-3/5">
+                  <div className="truncate">{event.type}</div>
                   <div className="text-xs">Not yet claimable</div>
                 </div>
                 <span className="font-semibold">{event.value} pts</span>

--- a/packages/ui/src/components/superchain-points.tsx
+++ b/packages/ui/src/components/superchain-points.tsx
@@ -46,7 +46,7 @@ export const SuperchainPoints: React.FC = () => {
 
   if (isPending) {
     return (
-      <div className="w-full">
+      <div className="w-full xl:w-[30%] 2xl:w-[25%]">
         <div className="mb-4 font-medium">Claimable Rewards</div>
         <div className="bg-white border rounded-lg p-8 space-y-4 h-[430px]">
           <Skeleton className="h-4 w-1/2 rounded-md" />
@@ -59,7 +59,7 @@ export const SuperchainPoints: React.FC = () => {
 
   if (events.length === 0 && claimable === 0n) {
     return (
-      <div>
+      <div className="xl:w-[30%] 2xl:w-[25%]">
         <div className="mb-4 font-medium">Claimable Rewards</div>
         <div className="bg-white border rounded-lg p-8 flex flex-col justify-center items-center h-[430px]">
           <img src={emptySvg} alt="" className="mb-11 h-20 w-20" />
@@ -76,7 +76,7 @@ export const SuperchainPoints: React.FC = () => {
   }
 
   return (
-    <div>
+    <div className="xl:w-[30%] 2xl:w-[25%]">
       <div className="mb-4 font-medium">Claimable Rewards</div>
       <div className="bg-white border rounded-lg p-8 h-[430px] flex flex-col">
         <ScrollArea className="h-full">
@@ -85,7 +85,7 @@ export const SuperchainPoints: React.FC = () => {
               <li className="flex justify-between first:pt-0 pt-4 pb-4">
                 <span className="font-semibold">Unknown</span>
                 <span className="font-semibold">
-                  {unknownAmount.toString()} points
+                  {unknownAmount.toString()} pts
                 </span>
               </li>
             )}
@@ -99,7 +99,7 @@ export const SuperchainPoints: React.FC = () => {
                   <div>{event.type}</div>
                   <div className="text-xs">{shortenAddress(event.transactionHash)}</div>
                 </div>
-                <span className="font-semibold">{event.value} points</span>
+                <span className="font-semibold">{event.value} pts</span>
               </li>
             ))}
 
@@ -112,7 +112,7 @@ export const SuperchainPoints: React.FC = () => {
                   <div>{event.type}</div>
                   <div className="text-xs">Not yet claimable</div>
                 </div>
-                <span className="font-semibold">{event.value} points</span>
+                <span className="font-semibold">{event.value} pts</span>
               </li>
             ))}
           </ul>

--- a/packages/ui/src/components/superchain-raffle.tsx
+++ b/packages/ui/src/components/superchain-raffle.tsx
@@ -39,7 +39,7 @@ export const SuperchainRaffle: React.FC = () => {
 
   if (isPending) {
     return (
-      <div className="w-full">
+      <div className="w-full xl:w-[35%] 2xl:w-[30%]">
         <div className="mb-4 font-medium">Superchain Raffle</div>
         <div className="bg-white border rounded-lg p-8 space-y-4 h-[430px]">
           <Skeleton className="h-4 w-1/2 rounded-md" />
@@ -52,7 +52,7 @@ export const SuperchainRaffle: React.FC = () => {
 
   if (!currentRaffle) {
     return (
-      <div>
+      <div className="xl:w-[35%] 2xl:w-[30%]">
         <div className="mb-4 font-medium">Superchain Raffle</div>
         <div className="bg-white border rounded-lg p-8 flex flex-col justify-center items-center h-[430px]">
           <img src={emptySvg} alt="" className="mb-11 h-20 w-20" />
@@ -68,7 +68,7 @@ export const SuperchainRaffle: React.FC = () => {
   }
 
   return (
-    <div>
+    <div className="xl:w-[35%] 2xl:w-[30%]">
       <div className="mb-4 font-medium">Superchain Raffle</div>
       <div className="bg-white border rounded-lg p-8 h-[430px] flex flex-col justify-between">
         <div>

--- a/packages/ui/src/components/superchain-raffle.tsx
+++ b/packages/ui/src/components/superchain-raffle.tsx
@@ -57,7 +57,7 @@ export const SuperchainRaffle: React.FC = () => {
         <div className="bg-white border rounded-lg p-8 flex flex-col justify-center items-center h-[430px]">
           <img src={emptySvg} alt="" className="mb-11 h-20 w-20" />
           <div className="text-center mb-6 font-medium">
-            Oops! No raffles currently ongoing
+            No raffles are ongoing... yet!
           </div>
           <div className="text-center text-muted-foreground">
             Be alert! New raffles may start anytime

--- a/packages/ui/src/hooks/use-superchain-points.tsx
+++ b/packages/ui/src/hooks/use-superchain-points.tsx
@@ -22,21 +22,11 @@ export const useSuperchainPoints = () => {
     enabled: address != zeroAddress,
     queryKey: ["superchainPoints", address ?? "0x0", chain.id],
     queryFn: async () => {
-      const [balance, claimable] = await chain.client.multicall({
-        contracts: [
-          {
-            address: envParsed().SUPERCHAIN_POINTS_ADDRESS as `0x${string}`,
-            abi: superchainPoints,
-            functionName: "balanceOf",
-            args: [address],
-          },
-          {
-            address: envParsed().SUPERCHAIN_POINTS_ADDRESS as `0x${string}`,
-            abi: superchainPoints,
-            functionName: "getClaimable",
-            args: [address],
-          },
-        ],
+      const claimable = await chain.client.readContract({
+        address: envParsed().SUPERCHAIN_POINTS_ADDRESS as `0x${string}`,
+        abi: superchainPoints,
+        functionName: "getClaimable",
+        args: [address],
       });
 
       const events = await pointsService.getUserPoints(
@@ -45,8 +35,7 @@ export const useSuperchainPoints = () => {
       );
 
       return {
-        balance: (balance.result as bigint) ?? 0n,
-        claimable: (claimable.result as bigint) ?? 0n,
+        claimable: (claimable as bigint) ?? 0n,
         events,
       };
     },
@@ -85,7 +74,6 @@ export const useSuperchainPoints = () => {
   return {
     isPending: isStatePending || data === undefined,
     claimable: data?.claimable ?? 0n,
-    balance: data?.balance ?? 0n,
     events: data?.events ?? [],
     isClaiming: isClaimingPoints || isSettingPointsClaimed,
     claim,

--- a/packages/ui/src/hooks/use-superchain-profile.tsx
+++ b/packages/ui/src/hooks/use-superchain-profile.tsx
@@ -4,6 +4,7 @@ import { useSuperChainAccount } from "./use-smart-account";
 import { Profile } from "schemas";
 
 const defaultProfile: Profile = {
+  points: 0,
   rank: "",
   position: {
     current: 0,

--- a/packages/ui/src/routes/_authenticated/profile.tsx
+++ b/packages/ui/src/routes/_authenticated/profile.tsx
@@ -12,18 +12,14 @@ export const Route = createFileRoute("/_authenticated/profile")({
 function Profile() {
   return (
     <div className="flex flex-col gap-8 w-full">
+      <AccountSummary />
       <div className="flex flex-col gap-4">
         <p className="text-bas font-medium">Networks</p>
         <ChainSelector />
       </div>
-
-      <AccountSummary />
-
-      <div className="flex flex-col lg:grid lg:grid-cols-[2fr_0.5fr_4fr] gap-6">
+      <div className="flex flex-col lg:grid lg:grid-cols-3 gap-6">
         <SuperchainRaffle />
-
         <SuperchainPoints />
-
         <SuperchainBadges />
       </div>
     </div>

--- a/packages/ui/src/routes/_authenticated/profile.tsx
+++ b/packages/ui/src/routes/_authenticated/profile.tsx
@@ -17,7 +17,7 @@ function Profile() {
         <p className="text-bas font-medium">Networks</p>
         <ChainSelector />
       </div>
-      <div className="flex flex-col lg:grid lg:grid-cols-3 gap-6">
+      <div className="flex flex-col xl:flex-row gap-6">
         <SuperchainRaffle />
         <SuperchainPoints />
         <SuperchainBadges />


### PR DESCRIPTION
## Ticket / Issue Tracking
<!-- Provide the ticket or issue number that this PR is addressing. -->
[OSA-141](https://wakeuplabs.atlassian.net/browse/OSA-141)

## 📝 Description
- UI improvements.
- Move the account summary component to the top of the page.
- The user's points in the account summary component represent the sum of all claimed points across the three chains.

### 📋 Test Cases / Scenarios

1. ✅ **Case 1: User can see the total points claimed in any chain**
   - Action: 
      - User logs into the application.
      - Then go to the `Profile` section, where they can see their total points claimed in the account summary component on top of the page. 
      - Then switch to another chain.
   - Expected Result: The user still sees the total points claimed in the account summary component after switching the chain.
---

### ⚙️ Test Methods
- [x] Manual testing
- [ ] Unit test (`/tests/feature/login.test.ts`)
- [ ] E2E test (`cypress/e2e/login.cy.js`)

---

### 📸 Evidence (if applicable)
https://www.loom.com/share/a2bcbc3135dd4541b7503fe93788c626?sid=08da1005-69ff-4b89-9ae1-adfd46aeea45


[OSA-141]: https://wakeuplabs.atlassian.net/browse/OSA-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ