### PR TITLE
[OSA-145] Fix: Set user position as las position when has no points

### DIFF
--- a/packages/api/src/services/users.ts
+++ b/packages/api/src/services/users.ts
@@ -58,15 +58,18 @@ export class UsersService implements IUserService {
           LEFT JOIN "PointEvent" pe ON pe."user" = u.wallet AND pe.claimed = true
           GROUP BY u.wallet
         ),
-        ranked_users AS (
-          SELECT 
-            "user",
-            total_points,
-            ROW_NUMBER() OVER (ORDER BY total_points DESC) AS current
-          FROM user_points
-        ),
         total_users AS (
            SELECT COUNT(*) AS total FROM user_points
+        ),
+        ranked_users AS (
+          SELECT 
+            up."user",
+            up.total_points,
+            CASE total_points
+              when 0 then tu.total
+              else ROW_NUMBER() OVER (ORDER BY up.total_points DESC) 
+            END AS current
+          FROM user_points up, total_users tu
         )
         SELECT 
             ru."user",


### PR DESCRIPTION
## Ticket / Issue Tracking
<!-- Provide the ticket or issue number that this PR is addressing. -->
[{OSA-145](https://wakeuplabs.atlassian.net/browse/OSA-145)

## 📝 Description
Set user position as last position when it has no points

### 📋 Test Cases / Scenarios
 
1. ✅ **Case 1: Happy path**
   - Action: 
      - A user with no points logs in and accesses the profile page.
   - Expected Result: The User sees 0 points and his position as the last one in the account summary component.

---

### ⚙️ Test Methods
- [x] Manual testing
- [ ] Unit test (`/tests/feature/login.test.ts`)
- [ ] E2E test (`cypress/e2e/login.cy.js`)

---

### 📸 Evidence (if applicable)
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/5f6c002a-cc70-46a3-8bc2-803f8fe47df8" />

